### PR TITLE
User show page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,16 @@
+# controllers/users_controller.rb
+
+class UsersController < ApplicationController
+
+  def show
+    @user = User.find_by(id: params[:id])
+
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name)
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,14 +3,9 @@
 class UsersController < ApplicationController
 
   def show
-    @user = User.find_by(id: params[:id])
-
+    require "pry"; binding.pry
+    @user = User.find(params[:id])
   end
 
-  private
-
-  def user_params
-    params.require(:user).permit(:name)
-  end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@
 class UsersController < ApplicationController
 
   def show
-    require "pry"; binding.pry
     @user = User.find(params[:id])
   end
 

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -10,7 +10,9 @@
 <p><% @book.reviews.each do |review| %></p>
 <ul>
   <li><%= review.title %></li>
-  <li><%= review.user.name %></li>
+
+  <li>Reviewer: <%= link_to review.user.name, user_path(review.user.id) %></li>
+
   <li>Rating: <%= review.rating %></li>
   <li><%= review.body %></li>
 </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,18 @@
 <!-- app/views/users/show.html.erb -->
 
 <h3>Reviews by <%= @user.name %></h3>
+
+<div>
+  <% @user.reviews.each do |review| %>
+  <p><%= review.title %></p>
+  <p>Rating <%= review.rating %></p>
+  <p><%= review.body %></p>
+  <p>Book: <%= review.book.title %></p>
+
+  <div class="thumbnail">
+    <img src="<%= review.book.cover_img %>"/>
+  </div>
+
+  <p>Review created: <%= review.created_at %></p>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/users/show.html.erb -->
+
+<h3>Reviews by <%= @user.name %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: "welcome#index"
-  
+
   resources :books, only: [:index, :new, :create, :destroy]
 
   resources :books, only: [:show] do
@@ -10,5 +10,7 @@ Rails.application.routes.draw do
   end
 
   resources :authors, only: [:show, :destroy]
+
+  resources :users, only: [:show]
 
 end

--- a/spec/features/reviews/new_spec.rb
+++ b/spec/features/reviews/new_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe "As a visitor, " do
       brian = User.create!(name: "Brian Plantico")
 
       review_1 = Review.create!(title: "Review 1", rating: 4, body: "This is the first review on this book", book_id: book_1.id, user_id: brian.id)
-# require "pry"; binding.pry
 
       visit book_path(book_1)
 

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "as a visitor, " do
+  describe "when I visit a book show page" do
+    before :each do
+      @book_1 = Book.create!(title: "Book 1", pages: 100, year_pub: 1901, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+      @book_2 = Book.create!(title: "Book 2", pages: 200, year_pub: 1902, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+      @book_3 = Book.create!(title: "Book 3", pages: 300, year_pub: 1903, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+
+      @author_1 = @book_1.authors.create!(name: "Author of Book 1", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+      @author_2 = @book_2.authors.create!(name: "Author of Book 2", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+      @author_3 = @book_3.authors.create!(name: "Author of Book 3", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+
+      @user_1 = User.create!(name: "User One")
+
+      @review_1 = @book_1.reviews.create!(title: "Review of Book 1", rating: 1, body: "stuff about book 1", user: @user_1 )
+      @review_2 = @book_2.reviews.create!(title: "Review of Book 2", rating: 2, body: "stuff about book 2", user: @user_1 )
+      @review_3 = @book_3.reviews.create!(title: "Review of Book 3", rating: 3, body: "stuff about book 3", user: @user_1 )
+    end
+
+    it "all the reviewer names are links to that user's show page" do
+
+      visit book_path(@book_1)
+
+      expect(page).to have_link("User One")
+
+    end
+
+    it "clicking a reviewer's name takes me to that user's show page" do
+
+      visit book_path(@book_1)
+
+      click_link "User One"
+      save_and_open_page
+      expect(current_path).to eq(user_path(@user_1.id))
+
+    end
+  
+  end
+end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -37,30 +37,49 @@ RSpec.describe "as a visitor, " do
       review_3 = @book_3.reviews.create!(title: "Review of Book 3", rating: 3, body: "stuff about book 3", user: user_1 )
 
       visit book_path(@book_1)
-      require "pry"; binding.pry
 
       click_link "User One"
 
-      expect(current_path).to eq(user_path(@user_1))
+      expect(current_path).to eq(user_path(user_1))
 
+    end
+  end
+
+  describe "when I visit a user show page" do
+    before :each do
+      @book_1 = Book.create!(title: "Book 1", pages: 100, year_pub: 1901, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+      @book_2 = Book.create!(title: "Book 2", pages: 200, year_pub: 1902, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+      @book_3 = Book.create!(title: "Book 3", pages: 300, year_pub: 1903, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+
+      @author_1 = @book_1.authors.create!(name: "Author of Book 1", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+      @author_2 = @book_2.authors.create!(name: "Author of Book 2", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+      @author_3 = @book_3.authors.create!(name: "Author of Book 3", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+
+      User.destroy_all
     end
 
     it "the reviewer's show page has their reviews with details" do
-      visit user_path(user_path(@user_1))
+      user_1 = User.create!(name: "User One")
 
-      expect(page).to have_content(@review_1.title)
-      expect(page).to have_content(@review_2.title)
-      expect(page).to have_content(@review_3.title)
+      review_1 = @book_1.reviews.create!(title: "Review of Book 1", rating: 1, body: "stuff about book 1", user: user_1 )
+      review_2 = @book_2.reviews.create!(title: "Review of Book 2", rating: 2, body: "stuff about book 2", user: user_1 )
+      review_3 = @book_3.reviews.create!(title: "Review of Book 3", rating: 3, body: "stuff about book 3", user: user_1 )
 
-      expect(page).to have_content(@review_1.body)
-      expect(page).to have_content(@review_2.body)
-      expect(page).to have_content(@review_3.body)
+      visit user_path(user_1)
+
+      expect(page).to have_content(review_1.title)
+      expect(page).to have_content(review_2.title)
+      expect(page).to have_content(review_3.title)
+
+      expect(page).to have_content(review_1.body)
+      expect(page).to have_content(review_2.body)
+      expect(page).to have_content(review_3.body)
 
       expect(page).to have_content(@book_1.title)
       expect(page).to have_content(@book_2.title)
       expect(page).to have_content(@book_3.title)
 
     end
-
   end
+
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -11,14 +11,16 @@ RSpec.describe "as a visitor, " do
       @author_2 = @book_2.authors.create!(name: "Author of Book 2", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
       @author_3 = @book_3.authors.create!(name: "Author of Book 3", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
 
-      @user_1 = User.create!(name: "User One")
+      User.destroy_all
 
-      @review_1 = @book_1.reviews.create!(title: "Review of Book 1", rating: 1, body: "stuff about book 1", user: @user_1 )
-      @review_2 = @book_2.reviews.create!(title: "Review of Book 2", rating: 2, body: "stuff about book 2", user: @user_1 )
-      @review_3 = @book_3.reviews.create!(title: "Review of Book 3", rating: 3, body: "stuff about book 3", user: @user_1 )
     end
 
     it "all the reviewer names are links to that user's show page" do
+      user_1 = User.create!(name: "User One")
+
+      review_1 = @book_1.reviews.create!(title: "Review of Book 1", rating: 1, body: "stuff about book 1", user: user_1 )
+      review_2 = @book_2.reviews.create!(title: "Review of Book 2", rating: 2, body: "stuff about book 2", user: user_1 )
+      review_3 = @book_3.reviews.create!(title: "Review of Book 3", rating: 3, body: "stuff about book 3", user: user_1 )
 
       visit book_path(@book_1)
 
@@ -28,13 +30,37 @@ RSpec.describe "as a visitor, " do
 
     it "clicking a reviewer's name takes me to that user's show page" do
 
+      user_1 = User.create!(name: "User One")
+
+      review_1 = @book_1.reviews.create!(title: "Review of Book 1", rating: 1, body: "stuff about book 1", user: user_1 )
+      review_2 = @book_2.reviews.create!(title: "Review of Book 2", rating: 2, body: "stuff about book 2", user: user_1 )
+      review_3 = @book_3.reviews.create!(title: "Review of Book 3", rating: 3, body: "stuff about book 3", user: user_1 )
+
       visit book_path(@book_1)
+      require "pry"; binding.pry
 
       click_link "User One"
-      save_and_open_page
-      expect(current_path).to eq(user_path(@user_1.id))
+
+      expect(current_path).to eq(user_path(@user_1))
 
     end
-  
+
+    it "the reviewer's show page has their reviews with details" do
+      visit user_path(user_path(@user_1))
+
+      expect(page).to have_content(@review_1.title)
+      expect(page).to have_content(@review_2.title)
+      expect(page).to have_content(@review_3.title)
+
+      expect(page).to have_content(@review_1.body)
+      expect(page).to have_content(@review_2.body)
+      expect(page).to have_content(@review_3.body)
+
+      expect(page).to have_content(@book_1.title)
+      expect(page).to have_content(@book_2.title)
+      expect(page).to have_content(@book_3.title)
+
+    end
+
   end
 end


### PR DESCRIPTION
What does this PR do?

This pull request adds the user show page which is accessed by clicking on the user's name which appears as a link on each books show page the above the user's review.

The user show page has the following details:
- title of review
- description of review (body)
- rating
- title of book
- thumbnail of cover img
- date review was created