### PR TITLE
Book show page stats

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -10,7 +10,11 @@ class Book < ApplicationRecord
   validates :title, uniqueness: true
 
   def average_rating
-    reviews.average(:rating)
+    if reviews.count > 0
+      reviews.average(:rating)
+    else
+      "No ratings have been added for this book yet."
+    end
   end
 
   def total_reviews
@@ -61,4 +65,15 @@ class Book < ApplicationRecord
         .order("avg_rating ASC, books.title")
         .limit(3)
   end
+
+  def best_three_reviews
+      reviews.order('rating DESC, title DESC')
+      .limit(3)
+  end
+
+  def worst_three_reviews
+    reviews.order('rating, title DESC')
+    .limit(3)
+  end
+
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -13,4 +13,8 @@ class Review < ApplicationRecord
     self.select(:user_id).pluck(:user_id)
   end
 
+  def reviewer_name(id)
+    User.find(id).name
+  end
+
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -21,7 +21,7 @@
       <% @book.worst_three_reviews.each do |review| %>
         <p><%= review.title %></p>
         <p>Rating: <%= review.rating %></p>
-        <p>Reviewer: <%= review.reviewer_name(review[:user_id]) %> </p>
+        <p>Reviewer: <%= link_to review.reviewer_name(review[:user_id]), user_path(review[:user_id]) %> </p>
         <p>------------------------------</p>
       <% end %>
     <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -9,7 +9,7 @@
       <% @book.best_three_reviews.each do |review| %>
         <p><%= review.title %></p>
         <p>Rating: <%= review.rating %></p>
-        <p>Reviewer: <%= review.reviewer_name(review[:user_id]) %> </p>
+        <p>Reviewer: <%= link_to review.reviewer_name(review[:user_id]), user_path(review[:user_id]) %> </p>
         <p>------------------------------</p>
       <% end %>
     <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,4 +1,34 @@
 <h1><%= @book.title %></h1>
+
+<div id="book-show-page-stats">
+  <p>Average Rating: <%= @book.average_rating %></p>
+
+  <div id="best-three-reviews">
+    <% if @book.reviews.count > 0 %>
+      <p>Best Reviews:</p>
+      <% @book.best_three_reviews.each do |review| %>
+        <p><%= review.title %></p>
+        <p>Rating: <%= review.rating %></p>
+        <p>Reviewer: <%= review.reviewer_name(review[:user_id]) %> </p>
+        <p>------------------------------</p>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div id="worst-three-reviews">
+    <% if @book.reviews.count > 0 %>
+      <p>Worst Reviews:</p>
+      <% @book.worst_three_reviews.each do |review| %>
+        <p><%= review.title %></p>
+        <p>Rating: <%= review.rating %></p>
+        <p>Reviewer: <%= review.reviewer_name(review[:user_id]) %> </p>
+        <p>------------------------------</p>
+      <% end %>
+    <% end %>
+  </div>
+
+</div>
+
 <% @book.authors.each do |author| %>
   <p>Author(s): <%= link_to author.name, author_path(author.id) %></p>
 <% end %>

--- a/spec/features/books/show_spec.rb
+++ b/spec/features/books/show_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "as a visitor, " do
   describe "when I visit a book show page" do
     before :each do
 
-      @book_1 = Book.create!(title: "Title 1", pages: 100, year_pub: 1901, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+      @book_1 = Book.create!(title: "Test Title 1", pages: 100, year_pub: 1901, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
       @book_2 = Book.create!(title: "Title 2", pages: 200, year_pub: 1902, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
       @book_3 = Book.create!(title: "Title 3", pages: 300, year_pub: 1903, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
 
@@ -19,12 +19,16 @@ RSpec.describe "as a visitor, " do
 
       @user_1 = User.create!(name: "User One")
       @user_2 = User.create!(name: "User Two")
+      @user_3 = User.create!(name: "User Three")
+      @user_4 = User.create!(name: "User Four")
 
       @review_1 = @book_1.reviews.create!(title: "Review 1", rating: 1, body: "stuff 1", user: @user_1 )
       @review_2 = @book_1.reviews.create!(title: "Review 2", rating: 2, body: "stuff 2", user: @user_2 )
+      @review_4 = @book_1.reviews.create!(title: "Review 4", rating: 4, body: "stuff 4", user: @user_3 )
+      @review_5 = @book_1.reviews.create!(title: "Review 5", rating: 5, body: "stuff 5", user: @user_4 )
 
       @review_3 = @book_2.reviews.create!(title: "Review 3", rating: 1, body: "stuff 3", user: @user_1 )
-      
+
     end
 
     it "shows details about the books" do
@@ -69,7 +73,7 @@ RSpec.describe "as a visitor, " do
     it "when I click on the Delete Book link, I am taken to Books Index page where I no longer see the deleted book." do
       visit book_path(@book_1)
       expect(page).to have_link("Delete Book")
-      expect(Review.count).to eq(3)
+      expect(Review.count).to eq(5)
       expect(Book.count).to eq(3)
 
       click_link "Delete Book"
@@ -81,6 +85,50 @@ RSpec.describe "as a visitor, " do
       expect(page).to have_content(@author_2.name)
       expect(Review.count).to eq(1)
       expect(Book.count).to eq(2)
+    end
+
+    it "I see an area on the page for statistics about reviews" do
+      visit book_path(@book_1)
+      
+      within "#book-show-page-stats" do
+        expect(page).to have_content("Average Rating: #{@book_1.average_rating}")
+
+        within "#best-three-reviews" do
+          expect(page).to have_content("Best Reviews:")
+          expect(page).to have_content("#{@review_5.title}")
+          expect(page).to have_content("#{@review_5.rating}")
+          expect(page).to have_content("#{@user_4.name}")
+
+          expect(page).to have_content("#{@review_4.title}")
+          expect(page).to have_content("#{@review_4.rating}")
+          expect(page).to have_content("#{@user_3.name}")
+
+          expect(page).to have_content("#{@review_2.title}")
+          expect(page).to have_content("#{@review_2.rating}")
+          expect(page).to have_content("#{@user_2.name}")
+        end
+
+        within "#worst-three-reviews" do
+          expect(page).to have_content("Worst Reviews:")
+          expect(page).to have_content("#{@review_1.title}")
+          expect(page).to have_content("#{@review_1.rating}")
+          expect(page).to have_content("#{@user_1.name}")
+
+          expect(page).to have_content("#{@review_2.title}")
+          expect(page).to have_content("#{@review_2.rating}")
+          expect(page).to have_content("#{@user_2.name}")
+
+          expect(page).to have_content("#{@review_4.title}")
+          expect(page).to have_content("#{@review_4.rating}")
+          expect(page).to have_content("#{@user_3.name}")
+        end
+
+
+      end
+      # - the top three reviews for this book (title, rating and user only)
+      # - the bottom three reviews for this book  (title, rating and user only)
+      # - the overall average rating of all reviews for this book
+
     end
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe Review do
       expect(Review.array_of_reviewer_ids).to eq([jeff.id, jp.id])
     end
 
+    describe "instance methods" do
+      before :each do
+        @book_1 = Book.create!(title: "Title 1", pages: 100, year_pub: 1901, cover_img: "https://media.wired.com/photos/5be4cd03db23f3775e466767/master/pass/books-521812297.jpg")
+
+        @author_1 = @book_1.authors.create!(name: "Author 1", author_img: "https://banner2.kisspng.com/20180516/zce/kisspng-shadow-person-dungeons-dragons-silhouette-art-5afc1fa5cf7d87.5508397315264726138499.jpg")
+
+        @user_1 = User.create!(name: "User One")
+
+        @review_1 = @book_1.reviews.create!(title: "Review 1", rating: 1, body: "stuff 1", user: @user_1 )
+
+      end
+
+      it "finds reviewer name given a user_id" do
+
+        within "#book-show-page-stats" do
+          expect(page).to have_content(@review_1.reviewer_name(@user_1.id))
+        end
+        
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
What does this PR do?

This pull request adds a statistics section to each book show page which shows the average rating for each book along with the three best reviews (highest rating), and three worst reviews (lowest ratings). If no ratings, average ratings displays a default message and sections for three best and three worst ratings don't appear.